### PR TITLE
upgrade: murmurhash

### DIFF
--- a/src/Multiformats.Hash/Multiformats.Hash.csproj
+++ b/src/Multiformats.Hash/Multiformats.Hash.csproj
@@ -33,16 +33,15 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.1.3" />
-    <PackageReference Include="Murmurhash-net-core" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <PackageReference Include="BouncyCastle" Version="1.8.1" />
-    <PackageReference Include="Murmurhash-net" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BinaryEncoding" Version="1.3.4" />
     <PackageReference Include="Multiformats.Base" Version="2.0.1" />
     <PackageReference Include="System.Composition" Version="1.1.0" />
+    <PackageReference Include="murmurhash" Version="1.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\lib\blake2b\*.cs" Exclude="..\..\lib\blake2b\**\AssemblyInfo.cs" />


### PR DESCRIPTION
replace murmurhash-net-core and murmurhash-net (1.0.0) with murmhash (1.0.2) which is compatible with both net461 and .net standard 1.6.

License: MIT
Signed-off-by: Trond Bråthen <tabrath@gmail.com>