### PR TITLE
upgrade: bouncycastle

### DIFF
--- a/src/Multiformats.Hash/Multiformats.Hash.csproj
+++ b/src/Multiformats.Hash/Multiformats.Hash.csproj
@@ -31,13 +31,8 @@
     <Optimize>true</Optimize>
     <DefineConstants>$(DefineConstants)</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.1.3" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="BouncyCastle" Version="1.8.1" />
-  </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.2" />
     <PackageReference Include="BinaryEncoding" Version="1.3.4" />
     <PackageReference Include="Multiformats.Base" Version="2.0.1" />
     <PackageReference Include="System.Composition" Version="1.1.0" />


### PR DESCRIPTION
using Portable.BouncyCastle (1.8.2) which is compatible with net461 and .net standard 1.6.

License: MIT
Signed-off-by: Trond Bråthen <tabrath@gmail.com>