### PR TITLE
fix: minimum length to 2 bytes

### DIFF
--- a/src/Multiformats.Hash/Multihash.cs
+++ b/src/Multiformats.Hash/Multihash.cs
@@ -104,7 +104,7 @@ namespace Multiformats.Hash
             if (buf == null)
                 throw new ArgumentNullException(nameof(buf));
 
-            if (buf.Length < 3)
+            if (buf.Length < 2)
                 throw new Exception("Too short");
 
             var offset = Binary.Varint.Read(buf, 0, out uint code);

--- a/test/Multiformats.Hash.Tests/MultihashTests.cs
+++ b/test/Multiformats.Hash.Tests/MultihashTests.cs
@@ -48,6 +48,8 @@ namespace Multiformats.Hash.Tests
         }
 
         [Theory]
+        [InlineData("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae", 0x00, "id")]
+        [InlineData("", 0x00, "id")]
         [InlineData("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33", 0x11, "sha1")]
         [InlineData("0beec7b5", 0x11, "sha1")]
         [InlineData("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae", 0x12, "sha2-256")]


### PR DESCRIPTION
to support 0 length id (0x00) hashes.

License: MIT
Signed-off-by: Trond Bråthen <tabrath@gmail.com>